### PR TITLE
Fix directories and conda envs with spaces not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Add autoactivate functionality on Conda by cding into a directory. (Only Unix-ba
 ## Instructions
 
 Add the sh's code inside your shell profile. You can find the shell profile by opening a terminal, cd ~ or cd $HOME, ls -a and search for a file called .bashrc || .zprofile || .zshrc (for sure there are other names for this file, search your profile file name on Google based on your OS).
-After you've find the file, just copy and paste the script and the end of it.
+After you've found the file, just copy and paste the script at the end of it.
 
 This script will run every time you launch the cd command and it will search for a .conda_config file in the directory your cding into.
 
@@ -25,9 +25,9 @@ As the script is really short I'll add it there also, so you can copy and paste.
 if [[ -n "$CONDA_SHLVL" ]]; then
     export CONDACONFIGDIR=""
     cd() { builtin cd "$@" && 
-    if [ -f $PWD/.conda_config ]; then
+    if [ -f "$PWD/.conda_config" ]; then
         export CONDACONFIGDIR=$PWD
-        conda activate $(cat .conda_config)
+        conda activate "$(cat .conda_config)"
     elif [ "$CONDACONFIGDIR" ]; then
         if [[ $PWD != *"$CONDACONFIGDIR"* ]]; then
             export CONDACONFIGDIR=""

--- a/addToShellProfile.sh
+++ b/addToShellProfile.sh
@@ -1,9 +1,9 @@
 if [[ -n "$CONDA_SHLVL" ]]; then
     export CONDACONFIGDIR=""
     cd() { builtin cd "$@" && 
-    if [ -f $PWD/.conda_config ]; then
+    if [ -f "$PWD/.conda_config" ]; then
         export CONDACONFIGDIR=$PWD
-        conda activate $(cat .conda_config)
+        conda activate "$(cat .conda_config)"
     elif [ "$CONDACONFIGDIR" ]; then
         if [[ $PWD != *"$CONDACONFIGDIR"* ]]; then
             export CONDACONFIGDIR=""


### PR DESCRIPTION
I fixed two errors I ran into. I also corrected a typo in the Readme.

- Entering a directory with spaces in the name leads to the following error: `bash: [: too many arguments`
This can be fixed by just quoting the whole path.
- After I fixed this, I thought that the same could happen with conda environments, since the same word splitting could occur with them: `ArgumentError: activate does not accept more than one argument: ['env', 'with', 'space']`

Btw, is nobody using spaces in their filenames or why wasn't this noticed...

Thank you for providing this useful script.