### PR TITLE
Bugfix: Changing from one folder directly to another leaves first env active in background

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,12 @@ function _z_do_conda_activate() {
     if [ "$CONDACONFIGDIR" ]; then
         if [[ $PWD != *"$CONDACONFIGDIR"* ]]; then
             export CONDACONFIGDIR=""
-            micromamba deactivate
+            conda deactivate
         fi
     fi
     if [ -f "$PWD/.conda_config" ]; then
         export CONDACONFIGDIR=$PWD
-        micromamba activate "$(cat .conda_config)"
+        conda activate "$(cat .conda_config)"
     fi
 }
 if [[ -n "$CONDA_SHLVL" ]]; then

--- a/README.md
+++ b/README.md
@@ -23,14 +23,15 @@ As the script is really short I'll add it there also, so you can copy and paste.
 
 ```bash
 function _z_do_conda_activate() {
-    if [ -f "$PWD/.conda_config" ]; then
-        export CONDACONFIGDIR=$PWD
-        conda activate "$(cat .conda_config)"
-    elif [ "$CONDACONFIGDIR" ]; then
+    if [ "$CONDACONFIGDIR" ]; then
         if [[ $PWD != *"$CONDACONFIGDIR"* ]]; then
             export CONDACONFIGDIR=""
-            conda deactivate
+            micromamba deactivate
         fi
+    fi
+    if [ -f "$PWD/.conda_config" ]; then
+        export CONDACONFIGDIR=$PWD
+        micromamba activate "$(cat .conda_config)"
     fi
 }
 if [[ -n "$CONDA_SHLVL" ]]; then

--- a/addToShellProfile.sh
+++ b/addToShellProfile.sh
@@ -2,12 +2,12 @@ function _z_do_conda_activate() {
     if [ "$CONDACONFIGDIR" ]; then
         if [[ $PWD != *"$CONDACONFIGDIR"* ]]; then
             export CONDACONFIGDIR=""
-            micromamba deactivate
+            conda deactivate
         fi
     fi
     if [ -f "$PWD/.conda_config" ]; then
         export CONDACONFIGDIR=$PWD
-        micromamba activate "$(cat .conda_config)"
+        conda activate "$(cat .conda_config)"
     fi
 }
 if [[ -n "$CONDA_SHLVL" ]]; then

--- a/addToShellProfile.sh
+++ b/addToShellProfile.sh
@@ -1,12 +1,13 @@
 function _z_do_conda_activate() {
-    if [ -f "$PWD/.conda_config" ]; then
-        export CONDACONFIGDIR=$PWD
-        conda activate "$(cat .conda_config)"
-    elif [ "$CONDACONFIGDIR" ]; then
+    if [ "$CONDACONFIGDIR" ]; then
         if [[ $PWD != *"$CONDACONFIGDIR"* ]]; then
             export CONDACONFIGDIR=""
-            conda deactivate
+            micromamba deactivate
         fi
+    fi
+    if [ -f "$PWD/.conda_config" ]; then
+        export CONDACONFIGDIR=$PWD
+        micromamba activate "$(cat .conda_config)"
     fi
 }
 if [[ -n "$CONDA_SHLVL" ]]; then


### PR DESCRIPTION
If you have:

```
project_a/
     .conda_config
    <other files>
project_b/
    .conda_config
    <other files>
```

Changing directories between `project_a` to `project_b` directly won't deactivate `(project_a)` environment. This is because the first part of the if statement checks if it should activate a new environment before it decides to deactivate the old one. So I swapped the order and removed it from `elif`.